### PR TITLE
Enhance song variation through random playlist creation 

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -15,7 +15,7 @@ mpd.songs = {}
 local sfile, sfileerr=io.open(mpd.modpath.."/songs.txt")
 if not sfile then error("Error opening songs.txt: "..sfileerr) end
 for line in sfile:lines() do
-	if line~="" and line[1]~="#" then
+	if line~="" and string.sub(line, 1, 1)~="#" then
 		local name, timeMinsStr, timeSecsStr, gainStr = string.match(line, "^(%S+)%s+(%d+):([%d%.]+)%s+([%d%.]+)$")
 		local timeMins, timeSecs, gain = tonumber(timeMinsStr), tonumber(timeSecsStr), tonumber(gainStr)
 		if name and timeMins and timeSecs and gain then


### PR DESCRIPTION
Imrpove song variation by creating random playlists instead of chosing a random song each time the next_song method is called. 
On first call of next_song a random playlist will be created and stored. The next song will be popped of the randomized playlist until there are no songs left to play. Once that happens a new randomized playlist will be created, containing all songs except the last one played.
~~This PR ensures that all songs are played at least once before a song that was played already gets played again.~~

Also fixes a small bug that occured by trying to read the first sign of each line on import of the songs.txt file. 