### PR TITLE
Fix setting name for pausing between songs so custom value can be read

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -2,7 +2,7 @@
 mpd={}
 
 
-mpd.pause_between_songs=minetest.settings:get("mpd.pause_between_songs") or 30
+mpd.pause_between_songs=tonumber(minetest.settings:get("mpd_pause_between_songs")) or 30
 
 --end config
 


### PR DESCRIPTION
Previously the setting name was misspelled in init.lua, so when you set
a custom value it wouldn't pick it up. Also, I cast the value to a
number b/c otherwise it tried to read it as a string which caused an
error that would crash the game.